### PR TITLE
[arcade] Sync 6c21f67 → 211de11

### DIFF
--- a/prereqs/git-info/arcade.props
+++ b/prereqs/git-info/arcade.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <GitCommitHash>6c21f67e543ad24ca689502d6476a0613deca219</GitCommitHash>
+    <GitCommitHash>211de115e871f6a5c809ad7c1e33fe70328ff16a</GitCommitHash>
     <OfficialBuildId>20250113.1</OfficialBuildId>
     <OutputPackageVersion>0.0.0</OutputPackageVersion>
   </PropertyGroup>

--- a/src/arcade/global.json
+++ b/src/arcade/global.json
@@ -1,0 +1,9 @@
+{
+  "tools": {
+    "dotnet": "2.2.203"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19251.6",
+    "Microsoft.DotNet.Helix.Sdk": "2.0.0-beta.19251.6"
+  }
+}

--- a/src/source-manifest.json
+++ b/src/source-manifest.json
@@ -5,7 +5,7 @@
       "barId": null,
       "path": "arcade",
       "remoteUri": "https://github.com/maestro-auth-test/fake-arcade",
-      "commitSha": "6c21f67e543ad24ca689502d6476a0613deca219"
+      "commitSha": "211de115e871f6a5c809ad7c1e33fe70328ff16a"
     },
     {
       "packageVersion": null,


### PR DESCRIPTION
Diff: https://github.com/maestro-auth-test/fake-arcade/compare/6c21f67e543ad24ca689502d6476a0613deca219..211de115e871f6a5c809ad7c1e33fe70328ff16a

From: https://github.com/maestro-auth-test/fake-arcade/commit/6c21f67e543ad24ca689502d6476a0613deca219
To: https://github.com/maestro-auth-test/fake-arcade/commit/211de115e871f6a5c809ad7c1e33fe70328ff16a

[[ commit created by automation ]]